### PR TITLE
Fixing typos

### DIFF
--- a/_data/glossary.yml
+++ b/_data/glossary.yml
@@ -1196,6 +1196,12 @@
   ref:
   - short_term_memory
 
+- key: magic_number
+  en:
+    term: magic number
+    def: >
+      A hardcoded value which could be replaced by a named constant.
+
 - key: mail_filter
   en:
     term: mail filter

--- a/_data/index.yml
+++ b/_data/index.yml
@@ -595,11 +595,11 @@
 - links:
   - slug: ip
     title: Intellectual Property
-  term: Creative Commons - ND clause
+  term: Creative Commons - no commercial use
 - links:
   - slug: ip
     title: Intellectual Property
-  term: Creative Commons - no commercial use
+  term: Creative Commons - no derivative works
 - links:
   - slug: ip
     title: Intellectual Property

--- a/communicate/index.md
+++ b/communicate/index.md
@@ -234,7 +234,7 @@ after lunch, everything is set up for me to focus on one topic at a time.
 
 <span i="software portal!communication tools">Software portals</span> provide
 many other ways to communicate, which project members use in a wide variety of
-ways <cite>Treude2011</cite>.  <span i="wiki; communication!wiki">Wikis/span>
+ways <cite>Treude2011</cite>.  <span i="wiki; communication!wiki">Wikis</span>
 seem like a good way to keep notes, create documentation, and so on. Their main
 strength is the fact that content is automatically and immediately visible on
 the web.  These days, you will probably get more mileage out of a bunch of <span
@@ -400,7 +400,7 @@ a different kind of documentation:
     by one and shows how they fit together.
 
 -   A <span i="competent practitioner!documentation needs; documentation!for
-    competent practitioners">competent practitioner needs reference guides,
+    competent practitioners">competent practitioner</span> needs reference guides,
     cookbooks, and Q&A sites; these give her solutions close enough to what she
     needs that she can tweak them the rest of the way.
 

--- a/git-solo/index.md
+++ b/git-solo/index.md
@@ -152,7 +152,7 @@ project">clone</span>. For example, if you want a clone of this book, you can do
 this:
 
 ```sh
-$ git clone https://github.com/gvwilson/bst.git
+$ git clone https://github.com/gvwilson/buildtogether.tech.git
 ```
 
 {: .continue}
@@ -349,8 +349,8 @@ get a list of remotes like this:
 $ git remote -v
 ```
 ```out
-origin	https://github.com/gvwilson/bst (fetch)
-origin	https://github.com/gvwilson/bst (push)
+origin	https://github.com/gvwilson/buildtogether.tech.git (fetch)
+origin	https://github.com/gvwilson/buildtogether.tech.git (push)
 ```
 
 {: .continue}
@@ -407,7 +407,7 @@ changes; we'll explore this in <span x="tooling"/>.
 So far we have only used a sequential timeline with Git: each change builds on
 the one before, and *only* on the one before.  However, there are times when we
 want to work on several things at once.  To do this, we can use <span i="branch
-(in Git); Git!branch"> g="branch_git">branches</span> to work on separate tasks
+(in Git); Git!branch">branches</span> to work on separate tasks
 in parallel.  Each branch is like a parallel timeline: changes made to one
 branch have no effect on other branches unless and until we explicitly merge
 them.

--- a/git-team/code-review.tbl
+++ b/git-team/code-review.tbl
@@ -1,6 +1,6 @@
 | Line(s) | Comment |
 | ------- | ------- |
-| 02      | Add a <span g="docstring">docstring</g> describing the program. |
+| 02      | Add a <span g="docstring">docstring</span> describing the program. |
 | 03      | Put imports in alphabetical order. |
 | 07      | Use a set instead of a list for faster lookup. |
 |         | One entry per line will be easier to read. |
@@ -11,7 +11,7 @@
 | 17      | Print error message to `sys.stderr`. |
 | 33      | Add a docstring describing this function. |
 | 34-39   | Use `any` instead of a loop to check this. |
-| 41      | <span g="magic-number">Magic number</span> 10. |
+| 41      | <span g="magic_number">Magic number</span> 10. |
 | 41      | Provide option to control progress reporting. |
 | 47      | Use `'rb'` to read files as binary. |
 | 57      | Add a docstring describing this function. |

--- a/important/index.md
+++ b/important/index.md
@@ -141,7 +141,7 @@ be---and pace yourself accordingly.
 I *have* to work extra hours to get them all done!" Sadly, that is often true:
 while people in industry joke that having two bosses means living in hell, most
 students can only dream of having just two, since most schools do a lousy job of
-coordinating due dates across differences courses.  <cite>Tregubov2017</cite>
+coordinating due dates across different courses.  <cite>Tregubov2017</cite>
 found strong correlation between the number of projects and the number of
 interruptions that developers reported, while <cite>Edwards2009</cite> found
 that starting assignments early and working consistently both predicted good

--- a/ip/index.md
+++ b/ip/index.md
@@ -237,8 +237,8 @@ usually referred two using the two-letter abbreviations listed below:
     permission, which we can give under whatever terms we want.  (We use the
     CC-BY-NC license for this work.)
 
--   <span i="Creative Commons!ND clause">no derivative works (no derivative
-    works)</span> prevents people from creating modified versions of our work.
+-   <span i="Creative Commons!no derivative works">ND (no derivative works)</span>
+    prevents people from creating modified versions of our work.
     Unfortunately, this also inhibits translation and reformatting.
 
 -   <span i="Creative Commons!share-alike">SA (share-alike)</span> requires people

--- a/teams/index.md
+++ b/teams/index.md
@@ -3,7 +3,7 @@
 
 Most people learn better together than they do on their own
 <cite>Michaelson2004</cite>.  As long as their teams <span i="teams!learning
-benefits of"work well</span>, they achieve higher grades, retain information
+benefits of">work well</span>, they achieve higher grades, retain information
 longer, are less likely to drop out of school, and graduate with better
 communication skills and a better understanding of what will be expected of them
 in their subsequent careers.


### PR DESCRIPTION
Thank you for writing this book - I heard about it via [Twitter](https://twitter.com/gvwilson/status/1383417255917019142).

I have started to read, and spotted a few minor typos along the way, which this PR fixes:

* Broken HTML tags (`teams/index.md`, `git-team/code-review.tbl`, ` communicate/index.md`)
* Added missing definition for "magic number" (in `_data/glossary.yml`, broken link was in `git-team/code-review.tbl`)
* Updated example Git repository to this _current_ repository for this book (`git-solo/index.md`)
* "ND clause", for consistency with the rest of the items on the Creative Commons list (`ip/index.md`)
* Other minor typo fixes (`important/index.md`, `git-solo/index.md`)