### PR TITLE
A bunch of small typos and one consistency issue

### DIFF
--- a/communicate/index.md
+++ b/communicate/index.md
@@ -85,7 +85,7 @@ The ID on the first line is assigned by the issue tracker, an often serves as a
 shorthand name for the issue in conversation. ("Hey, is anyone working on number
 fifty-five yet?") The date is in <span g="utc" i="issue!timestamps">UTC</span>
 so that it is unambiguous: while your team may all be in one place, it's
-increasingly likely that you are scattered across several timezones.
+increasingly likely that you are scattered across several time zones.
 
 The <span i="issue!good titles">title</span> on line 3 is probably the most
 important part of the issue. Projects will accumulate hundreds of issues over

--- a/delivery/index.md
+++ b/delivery/index.md
@@ -61,7 +61,7 @@ i="marketing">Marketing</span>, which is the process of figuring out how to tell
 the people you're trying to help how you can help them. This doesn't mean
 spamming people with discount coupons; instead, it means explaining the problem
 that the product will solve in ways that will reach the intended users.  I have
-been more startups fail because of poor marketing than because of poor
+seen more startups fail because of poor marketing than because of poor
 programming; it is also out of scope for this book, but <cite>Jackson2017</cite>
 is a good introduction.
 

--- a/fairness/index.md
+++ b/fairness/index.md
@@ -299,7 +299,7 @@ programmer to fix what's broken in our industry, but there is.  An <span
 i="ally" g="ally">ally</span> is a someone with unearned advantages who tries to
 understand their own privilege and create an environment that's fair for
 everyone.  As [this guide][dlf-active-bystander] from the [Digital Library
-Foundation][dlf] explains, there are several waysto be an <span i="active
+Foundation][dlf] explains, there are several ways to be an <span i="active
 bystander" g="active_bystander">active bystander</span>, i.e., several ways to
 <span i="lending privilege" g="lending_privilege">lend your privilege</span> to
 defuse situations and defend people who are being attacked.

--- a/git-solo/index.md
+++ b/git-solo/index.md
@@ -61,7 +61,7 @@ portal!GitHub" g="software_portal">software portal</span> in existence, and
 offers all of the tools a small software team needs. Other portals exist, such
 as <span i="Bitbucket; software portal!Bitbucket">[Bitbucket][bitbucket]</span>
 and <span i="GitLab; software portal!GitLab">[GitLab][gitlab]</span>, but
-GitHub's share of the educational market is even larger than than its share
+GitHub's share of the educational market is even larger than its share
 among professional developers.  If you're using anything in class, you're almost
 certainly using it, and it's probably helping you become a better programmer
 <cite>Hsing2019</cite>.
@@ -200,7 +200,7 @@ Each entry has:
 -   Two lines showing who saved the state of the project and when. The name and
     email address in the `Author` field are the ones we set up with `git
     config`; the <span g="timestamp" i="timestamp!of Git
-    commit">timestamp</span> is accurate to the second, and includes timezone
+    commit">timestamp</span> is accurate to the second, and includes time zone
     information like the `-0500` showing that I'm in Eastern time so that anyone
     in the world can tell exactly when these files were saved.
 
@@ -580,7 +580,7 @@ If the file `README.md` has been changed in both `main` and `homework4`,
 `git diff` will show the conflict:
 
 ```sh
-$ git diff homework4..main
+$ git diff homework4.main
 ```
 
 When we try to merge `homework4` into `main`, Git doesn't know which of these

--- a/important/index.md
+++ b/important/index.md
@@ -215,7 +215,7 @@ Take a ten-minute <span i="breaks (importance of regular)">break</span>.
     me for an hour can be solved by a five-minute walk.) When you're done, check
     that your to-do list is still in the right order and start again.
 
-If any task on your list is more than an hour long, break it down into into
+If any task on your list is more than an hour long, break it down into
 smaller pieces and prioritize those separately.  And keep in mind that the
 future is approaching at a fixed rate of one day every 24 hours: if something's
 going to take sixty hours to do you had better allow at least ten working days
@@ -543,7 +543,7 @@ way to do this in groups with up to a few dozen members
 Every group that uses Martha's Rules must make two procedural decisions:
 
 How are proposals put forward?
-:   The easiest way do do this in a software project is to file an issue in the
+:   The easiest way to do this in a software project is to file an issue in the
     project's issue tracker tagged *Proposal*.  Team members can then comment on
     the proposal, and the sponsor can revise it before bringing it to a vote.
 

--- a/methods/index.md
+++ b/methods/index.md
@@ -177,7 +177,7 @@ properly, and the only ones that could produce certain valuable insights.
 </div>
 
 <cite>Washburn2016</cite> demonstrates the kinds of insights these methods can
-produce. They analyzed 155 post mortem reviews of game projects to identify
+produce. They analyzed 155 postmortem reviews of game projects to identify
 characteristics of game development, link the characteristics to positive and
 negative experiences, and distill a set of best practices and pitfalls for game
 development. Their description of their method is worth repeating in full:

--- a/personal-eval/index.md
+++ b/personal-eval/index.md
@@ -106,6 +106,6 @@ Uses metrics for process improvement.
     this data into recommendations for process and/or product improvement.
 
 Contributes to project planning.
-:   Participates in post mortems; evaluates feasibility of design and feature
+:   Participates in postmortems; evaluates feasibility of design and feature
     proposals; explains technical issues/opportunities to upstream and
     downstream colleagues.

--- a/project-eval/index.md
+++ b/project-eval/index.md
@@ -38,7 +38,7 @@ How did you do?
 
 5 or less
 :   There is a lot of room for improvement, but don't try to fix everything at
-    once.  Instead, get the team to agree to tackle one thing at at time.
+    once.  Instead, get the team to agree to tackle one thing at time.
 
 6--10
 :   Most mature development teams are in this range and can bootstrap other

--- a/reading/index.md
+++ b/reading/index.md
@@ -64,7 +64,7 @@ therefore be very welcome.
 
 -   *Bury the Chains* <cite>Hochschild2006</cite>.  "Slavery was to the nineteenth
     century what oil is today: morally repugnant but economically
-    indispensible."  The fight against it was one of the first great triumphs of
+    indispensable."  The fight against it was one of the first great triumphs of
     democratic activism.
 
 -   *From the Ruins of Empire* <cite>Mishra2013</cite> and *Black Wave*

--- a/starting/index.md
+++ b/starting/index.md
@@ -196,7 +196,7 @@ Handoff
 Review
 :   The only way to get better at something is to reflect on how you've done and
     what you could have done better.  Every project should therefore end with a
-    post mortem in which team members talk about what went right and what went
+    postmortem in which team members talk about what went right and what went
     wrong.  As mentioned earlier, this may then be the subject of the final
     report.
 
@@ -245,7 +245,7 @@ Teamwork (10%)
 
 Final report (20%)
 :   This describes the architecture of the code as it was actually built (rather
-    than as it was designed) and summarizes the post mortem so that the next
+    than as it was designed) and summarizes the postmortem so that the next
     team can avoid any pitfalls this team ran into.
 
 Final state of project (20%)
@@ -353,7 +353,7 @@ website like this one, for example, the layout is:
 :   The directory containing the generated web pages. If the site doesn't need
     any special plugins, this directory doesn't have to be included in version
     control: GitHub will re-create it automatically. If the site does use
-    plugins, on the other hand, the authors have to generated the HTML and
+    plugins, on the other hand, the authors have to generate the HTML and
     commit it themselves.
 
 If your project's goal is to build a package, on the other hand, you will have

--- a/teams/index.md
+++ b/teams/index.md
@@ -86,7 +86,7 @@ If instructors create teams, they should <span i="teams!isolating at-risk
 students">avoid isolating at-risk students</span>.  Women and members of racial
 minority groups are more likely to drop out of computer science than other
 students, particularly in first and second year, and one of the main reasons is
-feeling isolated or out of place. Research has shown shown that putting at-risk
+feeling isolated or out of place. Research has shown that putting at-risk
 students together in the first couple of years can mitigate this problem
 <cite>Margolis2002</cite>. It is less necessary in upper years, since by then
 students have a stronger commitment to whatever program they're in, but it still
@@ -387,7 +387,7 @@ go through this list with your teammates and tell them what you'd like to get
 better at, they'll probably help you. And if what you want to get better at
 isn't on this list, please see <span x="contributing"/>.
 
-Not everything need to be completely correct.
+Not everything needs to be completely correct.
 :   Before correcting a factual error, ask yourself whether it really matters.
     If it's the name of the configuration file the program reads on startup, the
     answer is probably yes; if it's the name of a minor villain from the Marvel

--- a/tooling/index.md
+++ b/tooling/index.md
@@ -8,7 +8,7 @@ something are willing to invest time in learning how to do it better.
 
 I believe that processes are more important than tools, but that's because I
 know how to use whatever tools I have to support productive working practices.
-However, I focus on tools when talking to students because they are are more
+However, I focus on tools when talking to students because they are more
 tangible: it's easier to tell if someone is using version control or a style
 checker than it is to tell if they're designing or estimating sensibly.
 


### PR DESCRIPTION
- On a few occasions there is a word that has been repeated or missing a space, and this fixes that.
- The word 'post mortem/s' was used inconsistently. The most common usage was 'postmortem/s', so I changed the few 'post mortem/s' to that, although my thought would be that a space is appropriate and would prefer to add it everywhere.
- I changed timezone to time zone, but on reflection that was consistently used twice, so might be just a style thing, in which case you might prefer to reverse.
- Fix a couple of typos.